### PR TITLE
External Bank Accounts Refresh

### DIFF
--- a/CybridSDK.xcodeproj/project.pbxproj
+++ b/CybridSDK.xcodeproj/project.pbxproj
@@ -2369,7 +2369,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2427,7 +2427,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -2454,7 +2454,7 @@
 				INFOPLIST_FILE = CybridSDK/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2486,7 +2486,7 @@
 				INFOPLIST_FILE = CybridSDK/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2560,7 +2560,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2593,7 +2593,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/CybridSDK/Components/BankAccounts/Cell/BankAccountCell.swift
+++ b/CybridSDK/Components/BankAccounts/Cell/BankAccountCell.swift
@@ -14,6 +14,7 @@ class BankAccountCell: UITableViewCell {
     static let reuseIdentifier = "bankAccountsCell"
     override var reuseIdentifier: String? { Self.reuseIdentifier }
 
+    private var accountIcon = UIImageView()
     private var accountName = UILabel()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -35,29 +36,28 @@ class BankAccountCell: UITableViewCell {
     private func setupViews() {
 
         // -- Icon
-        let icon = UIImageView()
-        icon.translatesAutoresizingMaskIntoConstraints = false
-        icon.image = UIImage(named: "test_bank", in: Bundle(for: Self.self), with: nil)!
-        self.addSubview(icon)
-        icon.constraint(attribute: .leading,
-                        relatedBy: .equal,
-                        toItem: self,
-                        attribute: .leading,
-                        constant: 16)
-        icon.constraint(attribute: .centerY,
-                        relatedBy: .equal,
-                        toItem: self,
-                        attribute: .centerY)
-        icon.constraint(attribute: .height,
-                        relatedBy: .equal,
-                        toItem: nil,
-                        attribute: .notAnAttribute,
-                        constant: UIValues.iconSize.width)
-        icon.constraint(attribute: .width,
-                        relatedBy: .equal,
-                        toItem: nil,
-                        attribute: .notAnAttribute,
-                        constant: UIValues.iconSize.height)
+        self.accountIcon.translatesAutoresizingMaskIntoConstraints = false
+        self.accountIcon.image = UIImage(named: "test_bank", in: Bundle(for: Self.self), with: nil)!
+        self.addSubview(self.accountIcon)
+        self.accountIcon.constraint(attribute: .leading,
+                                    relatedBy: .equal,
+                                    toItem: self,
+                                    attribute: .leading,
+                                    constant: 16)
+        self.accountIcon.constraint(attribute: .centerY,
+                                    relatedBy: .equal,
+                                    toItem: self,
+                                    attribute: .centerY)
+        self.accountIcon.constraint(attribute: .height,
+                                    relatedBy: .equal,
+                                    toItem: nil,
+                                    attribute: .notAnAttribute,
+                                    constant: UIValues.iconSize.width)
+        self.accountIcon.constraint(attribute: .width,
+                                    relatedBy: .equal,
+                                    toItem: nil,
+                                    attribute: .notAnAttribute,
+                                    constant: UIValues.iconSize.height)
 
         // -- Account name label
         self.accountName.setContentHuggingPriority(.defaultHigh, for: .horizontal)
@@ -70,7 +70,7 @@ class BankAccountCell: UITableViewCell {
         self.addSubview(self.accountName)
         accountName.constraint(attribute: .leading,
                                relatedBy: .equal,
-                               toItem: icon,
+                               toItem: self.accountIcon,
                                attribute: .trailing,
                                constant: 15)
         accountName.constraint(attribute: .centerY,
@@ -90,6 +90,10 @@ class BankAccountCell: UITableViewCell {
     }
 
     func setData(account: ExternalBankAccountBankModel) {
+
+        if account.state == .refreshRequired {
+            self.accountIcon.image = UIImage(named: "kyc_error", in: Bundle(for: Self.self), with: nil)!
+        }
 
         let accountMask = account.plaidAccountMask ?? ""
         let accountName = account.plaidAccountName ?? ""

--- a/CybridSDK/Components/Transfer/TransferViewController+Extensions.swift
+++ b/CybridSDK/Components/Transfer/TransferViewController+Extensions.swift
@@ -146,6 +146,46 @@ extension TransferViewController {
 
     }
 
+    internal func transferView_Warning() {
+
+        // -- Title
+        self.createStateTitle(
+            stringKey: UIStrings.warningText,
+            image: UIImage(named: "kyc_required", in: Bundle(for: Self.self), with: nil)!
+        )
+
+        // -- Buttons
+        let done = CYBButton(title: localizer.localize(with: UIStrings.errorButton)) {
+            if self.navigationController != nil {
+                self.navigationController?.popViewController(animated: true)
+            } else {
+                self.dismiss(animated: true)
+            }
+        }
+
+        self.componentContent.addSubview(done)
+        done.constraint(attribute: .leading,
+                        relatedBy: .equal,
+                        toItem: self.componentContent,
+                        attribute: .leading,
+                        constant: UIValues.actionButtonMargin.left)
+        done.constraint(attribute: .trailing,
+                        relatedBy: .equal,
+                        toItem: self.componentContent,
+                        attribute: .trailing,
+                        constant: UIValues.actionButtonMargin.right)
+        done.constraint(attribute: .bottom,
+                        relatedBy: .equal,
+                        toItem: self.componentContent,
+                        attribute: .bottomMargin,
+                        constant: UIValues.actionButtonMargin.bottom)
+        done.constraint(attribute: .height,
+                        relatedBy: .equal,
+                        toItem: nil,
+                        attribute: .notAnAttribute,
+                        constant: UIValues.actionButtonHeight)
+    }
+
     internal func transferView_Error() {
 
         // -- Title
@@ -156,7 +196,11 @@ extension TransferViewController {
 
         // -- Buttons
         let done = CYBButton(title: localizer.localize(with: UIStrings.errorButton)) {
-            self.dismiss(animated: true)
+            if self.navigationController != nil {
+                self.navigationController?.popViewController(animated: true)
+            } else {
+                self.dismiss(animated: true)
+            }
         }
 
         self.componentContent.addSubview(done)
@@ -218,17 +262,17 @@ extension TransferViewController {
                         relatedBy: .equal,
                         toItem: title,
                         attribute: .leading,
-                        constant: -15)
+                        constant: -5)
         icon.constraint(attribute: .width,
                         relatedBy: .equal,
                         toItem: nil,
                         attribute: .notAnAttribute,
-                        constant: 25)
+                        constant: 20)
         icon.constraint(attribute: .height,
                         relatedBy: .equal,
                         toItem: nil,
                         attribute: .notAnAttribute,
-                        constant: 25)
+                        constant: 20)
     }
 
     func createSubTitleLabel(key: String) -> UILabel {
@@ -250,18 +294,18 @@ extension TransferViewController {
         let spinner = UIActivityIndicatorView(style: .medium)
         loaderContainer.addSubview(spinner)
         spinner.constraint(attribute: .centerY,
-                          relatedBy: .equal,
-                          toItem: loaderContainer,
-                          attribute: .centerY)
+                           relatedBy: .equal,
+                           toItem: loaderContainer,
+                           attribute: .centerY)
         spinner.constraint(attribute: .centerX,
-                          relatedBy: .equal,
-                          toItem: loaderContainer,
-                          attribute: .centerX)
+                           relatedBy: .equal,
+                           toItem: loaderContainer,
+                           attribute: .centerX)
         spinner.constraint(attribute: .width,
-                          relatedBy: .equal,
-                          toItem: nil,
-                          attribute: .notAnAttribute,
-                          constant: UIValues.loadingTitleHeight)
+                           relatedBy: .equal,
+                           toItem: nil,
+                           attribute: .notAnAttribute,
+                           constant: UIValues.loadingTitleHeight)
         spinner.constraint(attribute: .height,
                            relatedBy: .equal,
                            toItem: nil,
@@ -290,11 +334,16 @@ extension TransferViewController {
 
     func setFromFieldData(field: CYBTextField) {
 
-        let account = self.transferViewModel.externalBankAccounts.value.first
+        let account = self.transferViewModel.currentExternalBankAccount.value
         self.transferViewModel.currentExternalBankAccount.value = account
         let name = self.transferViewModel.getAccountNameInFormat(account)
 
-        field.updateIcon(.image("test_bank"))
+        if account?.state == .refreshRequired {
+            field.updateIcon(.image("kyc_error"))
+        } else {
+            field.updateIcon(.image("test_bank"))
+        }
+
         field.text = name
     }
 
@@ -384,7 +433,8 @@ extension TransferViewController {
 
         static let loadingText = "cybrid.transfer.loading.text"
         static let errorText = "cybrid.transfer.error.text"
-        static let errorButton = "cybrid.transfer.error.text"
+        static let warningText = "cybrid.transfer.warning.text"
+        static let errorButton = "cybrid.transfer.error.button"
         static let accountsTitleText = "cybrid.transfer.account.title.text"
         static let accountsDepositText = "cybrid.transfer.account.deposit.text"
         static let accountsWithdrawText = "cybrid.transfer.account.withdraw.text"

--- a/CybridSDK/Components/Transfer/TransferViewController.swift
+++ b/CybridSDK/Components/Transfer/TransferViewController.swift
@@ -82,7 +82,7 @@ extension TransferViewController {
                                          relatedBy: .equal,
                                          toItem: nil,
                                          attribute: .notAnAttribute,
-                                         constant: 20)
+                                         constant: 25)
         self.errorMessageView.isHidden = true
 
         // -- Component Container

--- a/CybridSDK/Components/Transfer/TransferViewController.swift
+++ b/CybridSDK/Components/Transfer/TransferViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public final class TransferViewController: UIViewController {
 
-    public enum ViewState { case LOADING, ACCOUNTS, ERROR }
+    public enum ViewState { case LOADING, ACCOUNTS, ERROR, WARNING }
     public enum ModalViewState { case LOADING, CONFIRM, DETAILS, ERROR }
     public enum BalanceViewState { case LOADING, CONTENT }
 
@@ -17,6 +17,7 @@ public final class TransferViewController: UIViewController {
     internal var theme: Theme!
     internal var localizer: Localizer!
 
+    internal var errorMessageView = UILabel()
     internal var componentContent = UIView()
     internal var currentState: Observable<ViewState> = .init(.LOADING)
 
@@ -56,13 +57,41 @@ extension TransferViewController {
 
     private func initComponentContent() {
 
+        // -- Error meesage view
+        self.errorMessageView.backgroundColor = UIColor.red
+        self.errorMessageView.textColor = UIColor.white
+        self.errorMessageView.font = UIFont.systemFont(ofSize: 14)
+        self.errorMessageView.textAlignment = .center
+        self.view.addSubview(self.errorMessageView)
+        self.errorMessageView.constraint(attribute: .top,
+                                         relatedBy: .equal,
+                                         toItem: self.view,
+                                         attribute: .topMargin,
+                                         constant: 0)
+        self.errorMessageView.constraint(attribute: .leading,
+                                         relatedBy: .equal,
+                                         toItem: self.view,
+                                         attribute: .leading,
+                                         constant: 10)
+        self.errorMessageView.constraint(attribute: .trailing,
+                                         relatedBy: .equal,
+                                         toItem: self.view,
+                                         attribute: .trailing,
+                                         constant: -10)
+        self.errorMessageView.constraint(attribute: .height,
+                                         relatedBy: .equal,
+                                         toItem: nil,
+                                         attribute: .notAnAttribute,
+                                         constant: 20)
+        self.errorMessageView.isHidden = true
+
         // -- Component Container
         self.view.addSubview(self.componentContent)
         self.componentContent.constraint(attribute: .top,
                                          relatedBy: .equal,
-                                         toItem: self.view,
-                                         attribute: .topMargin,
-                                         constant: 10)
+                                         toItem: self.errorMessageView,
+                                         attribute: .bottom,
+                                         constant: 0)
         self.componentContent.constraint(attribute: .leading,
                                          relatedBy: .equal,
                                          toItem: self.view,
@@ -82,6 +111,14 @@ extension TransferViewController {
 
     private func manageCurrentStateUI() {
 
+        // -- Await for error message UI
+        self.transferViewModel.errorMessage.bind { error in
+            if error {
+                self.errorMessageView.isHidden = false
+                self.errorMessageView.text = self.localizer.localize(with: "cybrid.transfer.errorMessage.text")
+            }
+        }
+
         // -- Await for UI State changes
         self.currentState.bind { state in
 
@@ -96,6 +133,9 @@ extension TransferViewController {
 
             case .ERROR:
                 self.transferView_Error()
+
+            case .WARNING:
+                self.transferView_Warning()
             }
         }
     }

--- a/CybridSDK/Components/Transfer/View/TransferViewModel.swift
+++ b/CybridSDK/Components/Transfer/View/TransferViewModel.swift
@@ -92,7 +92,6 @@ class TransferViewModel: NSObject {
 
                 self?.logger?.log(.component(.accounts(.accountsDataFetching)))
                 self?.checkExternalBankAccounts(accounts: accountList.objects)
-                // self?.checkExternalBankAccounts(accounts: [])
 
             case .failure:
                 self?.logger?.log(.component(.accounts(.accountsDataError)))

--- a/CybridSDK/Components/Transfer/View/TransferViewModel.swift
+++ b/CybridSDK/Components/Transfer/View/TransferViewModel.swift
@@ -25,6 +25,8 @@ class TransferViewModel: NSObject {
     internal var currentQuote: Observable<QuoteBankModel?> = .init(nil)
     internal var currentTransfer: Observable<TransferBankModel?> = .init(nil)
 
+    internal var errorMessage: Observable<Bool> = .init(false)
+
     internal var currentExternalBankAccount: Observable<ExternalBankAccountBankModel?> = .init(nil)
     internal var isWithdraw: Observable<Bool> = .init(false)
     internal var amount: String = ""
@@ -89,10 +91,8 @@ class TransferViewModel: NSObject {
             case .success(let accountList):
 
                 self?.logger?.log(.component(.accounts(.accountsDataFetching)))
-                self?.externalBankAccounts.value = accountList.objects
-                self?.calculateFiatBalance()
-                self?.uiState.value = .ACCOUNTS
-                self?.createAccountsPolling()
+                self?.checkExternalBankAccounts(accounts: accountList.objects)
+                // self?.checkExternalBankAccounts(accounts: [])
 
             case .failure:
                 self?.logger?.log(.component(.accounts(.accountsDataError)))
@@ -104,6 +104,23 @@ class TransferViewModel: NSObject {
 
         self.accountsPolling = Polling(interval: 8) {
             self.fetchAccountsInPolling()
+        }
+    }
+
+    func checkExternalBankAccounts(accounts: [ExternalBankAccountBankModel]) {
+
+        self.externalBankAccounts.value = accounts
+        if !accounts.isEmpty {
+
+            self.currentExternalBankAccount.value = accounts.first
+            self.calculateFiatBalance()
+            self.uiState.value = .ACCOUNTS
+            self.createAccountsPolling()
+            for account in accounts where account.state == .refreshRequired {
+                self.errorMessage.value = true
+            }
+        } else {
+            self.uiState.value = .WARNING
         }
     }
 

--- a/CybridSDK/Utilities/Localization/en.lproj/Localizable.strings
+++ b/CybridSDK/Utilities/Localization/en.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 
 // -- Transfer Component
 "cybrid.transfer.loading.text" = "Loading";
+"cybrid.transfer.warning.text" = "You need one account to transfer founds.";
 "cybrid.transfer.error.text" = "Error fetching accounts, try again.";
 "cybrid.transfer.error.button" = "Done";
 "cybrid.transfer.account.title.text" = "Available to Trade";
@@ -153,3 +154,4 @@
 "cybrid.transfer.modal.error.title.text" = "Action error";
 "cybrid.transfer.modal.error.desc.text" = "There was an error accessing your bank account. Please try again or contact support.";
 "cybrid.transfer.modal.error.doneButton.text" = "Done";
+"cybrid.transfer.errorMessage.text" = "Some of your accounts have a problem, please reconnect it.";

--- a/CybridSDK/Utilities/Localization/fr.lproj/Localizable.strings
+++ b/CybridSDK/Utilities/Localization/fr.lproj/Localizable.strings
@@ -118,3 +118,4 @@
 "cybrid.transfer.modal.error.title.text" = "Erreur d'action";
 "cybrid.transfer.modal.error.desc.text" = "Une erreur s'est produite lors de l'accès à votre compte bancaire. Veuillez réessayer ou contacter l'assistance.";
 "cybrid.transfer.modal.error.doneButton.text" = "Fait";
+"cybrid.transfer.errorMessage.text" = "Certains de vos comptes ont un problème, veuillez le reconnecter.";

--- a/CybridSDKTests/Components/Transfer/View/TransferViewModelTest.swift
+++ b/CybridSDKTests/Components/Transfer/View/TransferViewModelTest.swift
@@ -90,6 +90,24 @@ class TransferViewModelTest: XCTestCase {
         XCTAssertEqual(viewModel.modalUIState.value, .LOADING)
     }
 
+    func test_fetchExternalAccounts_Successfully_Empty() {
+
+        // -- Given
+        let viewModel = createViewModel()
+
+        // -- When
+        viewModel.modalUIState.value = .LOADING
+        dataProvider.fetchExternalBankAccountsSuccessfully_Empty()
+        viewModel.fetchExternalAccounts()
+        dataProvider.fetchExternalBankAccountsSuccessfully_Empty()
+
+        // -- Then
+        XCTAssertNotNil(viewModel)
+        XCTAssertTrue(viewModel.externalBankAccounts.value.isEmpty)
+        XCTAssertEqual(viewModel.uiState.value, .WARNING)
+        XCTAssertEqual(viewModel.modalUIState.value, .LOADING)
+    }
+
     func test_createQuote_Successfully() {
 
         // -- Given

--- a/CybridSDKTests/Components/Transfer/View/TransferViewModelTest.swift
+++ b/CybridSDKTests/Components/Transfer/View/TransferViewModelTest.swift
@@ -108,6 +108,36 @@ class TransferViewModelTest: XCTestCase {
         XCTAssertEqual(viewModel.modalUIState.value, .LOADING)
     }
 
+    func test_checkExternalBankAccounts_Without_Refresh() {
+
+        // -- Given
+        let viewModel = createViewModel()
+
+        // -- When
+        viewModel.modalUIState.value = .LOADING
+        viewModel.checkExternalBankAccounts(accounts: ExternalBankAccountBankModel.list)
+
+        // -- Then
+        XCTAssertEqual(viewModel.uiState.value, .ACCOUNTS)
+        XCTAssertNotNil(viewModel.accountsPolling)
+        XCTAssertEqual(viewModel.errorMessage.value, false)
+    }
+
+    func test_checkExternalBankAccounts_With_Refresh() {
+
+        // -- Given
+        let viewModel = createViewModel()
+
+        // -- When
+        viewModel.modalUIState.value = .LOADING
+        viewModel.checkExternalBankAccounts(accounts: ExternalBankAccountBankModel.listRefresh)
+
+        // -- Then
+        XCTAssertEqual(viewModel.uiState.value, .ACCOUNTS)
+        XCTAssertNotNil(viewModel.accountsPolling)
+        XCTAssertEqual(viewModel.errorMessage.value, true)
+    }
+
     func test_createQuote_Successfully() {
 
         // -- Given

--- a/CybridSDKTests/Components/Transfer/View/TransferViewModelTest.swift
+++ b/CybridSDKTests/Components/Transfer/View/TransferViewModelTest.swift
@@ -77,6 +77,7 @@ class TransferViewModelTest: XCTestCase {
         let viewModel = createViewModel()
 
         // -- When
+        viewModel.modalUIState.value = .LOADING
         dataProvider.fetchExternalBankAccountsSuccessfully()
         viewModel.fetchExternalAccounts()
         dataProvider.fetchExternalBankAccountsSuccessfully()
@@ -87,7 +88,6 @@ class TransferViewModelTest: XCTestCase {
         XCTAssertFalse(viewModel.externalBankAccounts.value.isEmpty)
         XCTAssertEqual(viewModel.uiState.value, .ACCOUNTS)
         XCTAssertEqual(viewModel.modalUIState.value, .LOADING)
-        XCTAssertEqual(viewModel.balanceLoading.value, .CONTENT)
     }
 
     func test_createQuote_Successfully() {

--- a/CybridSDKTests/Mocks/ExternalBankAccount/ExternalBankAccountAPIMock.swift
+++ b/CybridSDKTests/Mocks/ExternalBankAccount/ExternalBankAccountAPIMock.swift
@@ -146,7 +146,25 @@ extension ExternalBankAccountBankModel {
         state: .completed)
     }
 
+    static func mockRefresh() -> Self {
+        return ExternalBankAccountBankModel(
+        guid: "1234",
+        name: "test",
+        asset: "test",
+        accountKind: .plaid,
+        environment: .sandbox,
+        bankGuid: "1234",
+        customerGuid: "1234",
+        createdAt: Date(),
+        plaidInstitutionId: "1234",
+        plaidAccountMask: "1234",
+        plaidAccountName: "test",
+        state: .refreshRequired)
+    }
+
     static let list = [
         mock()
     ]
+
+    static let listRefresh = [ mockRefresh() ]
 }

--- a/CybridSDKTests/Mocks/ExternalBankAccount/ExternalBankAccountAPIMock.swift
+++ b/CybridSDKTests/Mocks/ExternalBankAccount/ExternalBankAccountAPIMock.swift
@@ -83,6 +83,12 @@ final class ExternalBankAccountAPIMock: ExternalBankAccountsAPI {
         return ExternalBankAccountListBankModel.mock
     }
 
+    @discardableResult
+    class func fetchExternalBankAccountsSuccessfully_Empty() -> ExternalBankAccountListBankModel {
+        fetchExternalBankAccountsCompletion?(.success(ExternalBankAccountListBankModel.mockEmpty))
+        return ExternalBankAccountListBankModel.mock
+    }
+
     class func fetchExternalBankAccountsError() {
         fetchExternalBankAccountsCompletion?(.failure(.error(0, nil, nil, CybridError.serviceError)))
     }
@@ -102,6 +108,8 @@ final class ExternalBankAccountAPIMock: ExternalBankAccountsAPI {
 extension ExternalBankAccountListBankModel {
 
     static let mock = ExternalBankAccountListBankModel(total: 1, page: 0, perPage: 1, objects: ExternalBankAccountBankModel.list)
+
+    static let mockEmpty = ExternalBankAccountListBankModel(total: 0, page: 0, perPage: 0, objects: [])
 }
 
 extension ExternalBankAccountBankModel {

--- a/CybridSDKTests/Mocks/ServiceProviderMock.swift
+++ b/CybridSDKTests/Mocks/ServiceProviderMock.swift
@@ -287,6 +287,12 @@ final class ServiceProviderMock: AssetsRepoProvider,
         ExternalBankAccountAPIMock.fetchExternalBankAccountsSuccessfully()
     }
 
+    func fetchExternalBankAccountsSuccessfully_Empty() {
+
+        Cybrid.session.setupSession(authToken: "TEST-TOKEN")
+        ExternalBankAccountAPIMock.fetchExternalBankAccountsSuccessfully_Empty()
+    }
+
     func fetchExternalBankAccountsFailed() {
 
         Cybrid.session.setupSession(authToken: "TEST-TOKEN")


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue

https://cybrid.atlassian.net/browse/CYB-1186

### Why

This PR add:

- Warning message if there is not account connected
- Error label if some account has problem `refresh_required`
- Add icon error in ExternalBankModel list

Limitations:

We need to add fully integration with Persona to can reconnect in iOS

### Evidence


