### PR TITLE
Fix errors for release 1.9

### DIFF
--- a/CybridSDK/Components/Accounts/AccountTradesViewController.swift
+++ b/CybridSDK/Components/Accounts/AccountTradesViewController.swift
@@ -120,7 +120,7 @@ extension AccountTradesViewController {
         balanceFiatValueView.setAttributedText(mainText: balance.accountBalanceInFiatFormatted,
                                                mainTextFont: UIValues.balanceFiatValueFont,
                                                mainTextColor: UIValues.balanceFiatValueColor,
-                                               attributedText: balance.asset?.code ?? "",
+                                               attributedText: balance.counterAsset?.code ?? "",
                                                attributedTextFont: UIValues.balanceFiatValueCodeFont,
                                                attributedTextColor: UIValues.balanceFiatValueCodeColor)
         balanceFiatValueView.addBelow(

--- a/CybridSDK/Components/Accounts/Entity/BalanceUIModel.swift
+++ b/CybridSDK/Components/Accounts/Entity/BalanceUIModel.swift
@@ -27,7 +27,7 @@ struct BalanceUIModel: Equatable {
     let buyPriceFormatted: String
     let accountAssetURL: String
 
-    init?(
+    init(
         account: AccountBankModel,
         asset: AssetBankModel?, // BTC
         counterAsset: AssetBankModel?, // USD

--- a/CybridSDKTestApp/RootViewController.swift
+++ b/CybridSDKTestApp/RootViewController.swift
@@ -18,24 +18,34 @@ class RootViewController: UIViewController {
     let viewController = TradeViewController()
     navigationController?.pushViewController(viewController, animated: true)
   }
-  
+
   @IBAction func didTapTransfersButton(_ sender: Any) {
     let viewController = TransferViewController()
     navigationController?.pushViewController(viewController, animated: true)
   }
-  
+
   @IBAction func didTapAccountsButton(_ sender: Any) {
     let viewController = AccountsViewController()
     navigationController?.pushViewController(viewController, animated: true)
   }
-  
+
   @IBAction func didTapKYCButton(_ sender: Any) {
     let viewController = IdentityVerificationViewController()
     navigationController?.pushViewController(viewController, animated: true)
   }
-  
+
   @IBAction func didTapBankAccountsButton(_ sender: Any) {
     let viewController = BankAccountsViewController()
     navigationController?.pushViewController(viewController, animated: true)
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    navigationController?.setNavigationBarHidden(false, animated: animated)
   }
 }

--- a/CybridSDKTests/Components/Accounts/Entity/BalanceUIModelTest.swift
+++ b/CybridSDKTests/Components/Accounts/Entity/BalanceUIModelTest.swift
@@ -43,9 +43,9 @@ class BalanceUIModelTest: XCTestCase {
             price: price)
 
         // -- Then
-        XCTAssertEqual(balance?.accountBalance.value, BigDecimal(0).value)
-        XCTAssertEqual(balance?.accountAvailable.value, BigDecimal(0).value)
-        XCTAssertEqual(balance?.buyPriceFormatted, "₿0.00000000")
+        XCTAssertEqual(balance.accountBalance.value, BigDecimal(0).value)
+        XCTAssertEqual(balance.accountAvailable.value, BigDecimal(0).value)
+        XCTAssertEqual(balance.buyPriceFormatted, "₿0.00000000")
     }
 
     func test_init_with_undefined() {
@@ -80,9 +80,9 @@ class BalanceUIModelTest: XCTestCase {
             price: price)
 
         // -- Then
-        XCTAssertEqual(balance?.accountBalance.value, BigDecimal(0).value)
-        XCTAssertEqual(balance?.accountAvailable.value, BigDecimal(0).value)
-        XCTAssertEqual(balance?.buyPriceFormatted, "₿0.00")
-        XCTAssertEqual(balance?.accountAssetURL, "https://images.cybrid.xyz/sdk/assets/pdf/color/.pdf")
+        XCTAssertEqual(balance.accountBalance.value, BigDecimal(0).value)
+        XCTAssertEqual(balance.accountAvailable.value, BigDecimal(0).value)
+        XCTAssertEqual(balance.buyPriceFormatted, "₿0.00")
+        XCTAssertEqual(balance.accountAssetURL, "https://images.cybrid.xyz/sdk/assets/pdf/color/.pdf")
     }
 }

--- a/CybridSDKTests/Components/Accounts/View/AccountTradesViewModelTest.swift
+++ b/CybridSDKTests/Components/Accounts/View/AccountTradesViewModelTest.swift
@@ -131,7 +131,7 @@ class AccountTradesViewModelTests: XCTestCase {
             dataProvider: self.dataProvider,
             logger: nil)
         let controller = AccountTradesViewController(
-            balance: balance!,
+            balance: balance,
             accountsViewModel: accountsViewModel)
         let tableView = controller.tradesTable
         let viewModel = AccountTradesViewModel(
@@ -162,7 +162,7 @@ class AccountTradesViewModelTests: XCTestCase {
             dataProvider: self.dataProvider,
             logger: nil)
         let controller = AccountTradesViewController(
-            balance: balance!,
+            balance: balance,
             accountsViewModel: accountsViewModel)
         let tableView = controller.tradesTable
         let viewModel = AccountTradesViewModel(
@@ -195,7 +195,7 @@ class AccountTradesViewModelTests: XCTestCase {
             dataProvider: self.dataProvider,
             logger: nil)
         let controller = AccountTradesViewController(
-            balance: balance!,
+            balance: balance,
             accountsViewModel: accountsViewModel)
         let tableView = controller.tradesTable
         let viewModel = AccountTradesViewModel(
@@ -228,7 +228,7 @@ class AccountTradesViewModelTests: XCTestCase {
             dataProvider: self.dataProvider,
             logger: nil)
         let controller = AccountTradesViewController(
-            balance: balance!,
+            balance: balance,
             accountsViewModel: accountsViewModel)
         let tableView = controller.tradesTable
         let viewModel = AccountTradesViewModel(

--- a/CybridSDKTests/Components/Accounts/View/AccountTransfersViewModelTest.swift
+++ b/CybridSDKTests/Components/Accounts/View/AccountTransfersViewModelTest.swift
@@ -67,7 +67,7 @@ class AccountTransfersViewModelTest: XCTestCase {
             asset: AssetBankModel.bitcoin,
             counterAsset: AssetBankModel.usd,
             price: SymbolPriceBankModel.btcUSD1)
-        let controller = AccountTransfersViewController(balance: balance!)
+        let controller = AccountTransfersViewController(balance: balance)
         let tableView = controller.transfersTable
         let viewModel = AccountTransfersViewModel(
             cellProvider: controller,
@@ -91,7 +91,7 @@ class AccountTransfersViewModelTest: XCTestCase {
             asset: AssetBankModel.bitcoin,
             counterAsset: AssetBankModel.usd,
             price: SymbolPriceBankModel.btcUSD1)
-        let controller = AccountTransfersViewController(balance: balance!)
+        let controller = AccountTransfersViewController(balance: balance)
         let tableView = controller.transfersTable
         let viewModel = AccountTransfersViewModel(
             cellProvider: controller,
@@ -117,7 +117,7 @@ class AccountTransfersViewModelTest: XCTestCase {
             asset: AssetBankModel.bitcoin,
             counterAsset: AssetBankModel.usd,
             price: SymbolPriceBankModel.btcUSD1)
-        let controller = AccountTransfersViewController(balance: balance!)
+        let controller = AccountTransfersViewController(balance: balance)
         let tableView = controller.transfersTable
         let viewModel = AccountTransfersViewModel(
             cellProvider: controller,

--- a/CybridSDKTests/Components/Accounts/View/AccountsViewModelTest.swift
+++ b/CybridSDKTests/Components/Accounts/View/AccountsViewModelTest.swift
@@ -85,10 +85,42 @@ class AccountsViewModelTest: XCTestCase {
         XCTAssertFalse(viewModel.balances.value.isEmpty)
     }
 
-    func test_buildModelList() {
+    func test_createAccountsFormatted_With_Default_Case() {
 
         // -- Given
         let viewModel = self.createViewModel()
+
+        // -- When
+        viewModel.assets = AssetBankModel.cryptoAssets
+        viewModel.accounts = AccountBankModel.mockWithBackstopped
+        viewModel.prices = .mockPrices
+        viewModel.createAccountsFormatted()
+
+        // -- Then
+        XCTAssertFalse(viewModel.balances.value.isEmpty)
+        XCTAssertTrue(viewModel.balances.value.count == 3)
+    }
+
+    func test_createAccountsFormatted_Order_Trading_Accounts() {
+
+        // -- Given
+        let viewModel = self.createViewModel()
+
+        // -- When
+        viewModel.assets = AssetBankModel.cryptoAssets
+        viewModel.accounts = AccountBankModel.mockWithBackstopped
+        viewModel.prices = .mockPrices
+        viewModel.createAccountsFormatted()
+
+        // -- Then
+        XCTAssertFalse(viewModel.balances.value.isEmpty)
+        XCTAssertTrue(viewModel.balances.value.count == 3)
+        XCTAssertTrue(viewModel.balances.value[0].account.asset == "USD")
+        XCTAssertTrue(viewModel.balances.value[1].account.asset == "BTC")
+        XCTAssertTrue(viewModel.balances.value[2].account.asset == "ETH")
+    }
+
+    func test_buildModelList() {
 
         // -- When
         let balances = self.createBalanceList()
@@ -177,7 +209,7 @@ class AccountsViewModelTest: XCTestCase {
         tableView.reloadData()
 
         // -- Then
-        XCTAssertTrue(viewModel.tableView(tableView, cellForRowAt: indexPath).isKind(of: AccountsCell.self))
+        XCTAssertTrue(viewModel.tableView(tableView, cellForRowAt: indexPath).isKind(of: AccountsFiatCell.self))
     }
 
     func test_TableView_didSelectRowAtIndex() throws {

--- a/CybridSDKTests/Mocks/Accounts/AccountsAPIMock.swift
+++ b/CybridSDKTests/Mocks/Accounts/AccountsAPIMock.swift
@@ -57,6 +57,19 @@ extension AccountBankModel {
         state: .created
     )
 
+    static let tradingETH = AccountBankModel(
+        type: .trading,
+        guid: "GUID",
+        createdAt: Date(),
+        asset: "ETH",
+        name: "ETH-USD",
+        bankGuid: "BANK_GUID",
+        customerGuid: "CUSTOMER_GUID",
+        platformBalance: "200000000",
+        platformAvailable: "2000000000",
+        state: .created
+    )
+
     static let tradingBalanceNil = AccountBankModel(
         type: .trading,
         guid: "GUID",
@@ -122,6 +135,19 @@ extension AccountBankModel {
         state: .created
     )
 
+    static let backstopped = AccountBankModel(
+        type: .backstopped,
+        guid: "GUID",
+        createdAt: Date(),
+        asset: "USD",
+        name: "USD",
+        bankGuid: "BANK_GUID",
+        customerGuid: "CUSTOMER_GUID",
+        platformBalance: "200",
+        platformAvailable: "200",
+        state: .created
+    )
+
     static let mock = [
         AccountBankModel.trading,
         AccountBankModel.fiat,
@@ -136,5 +162,12 @@ extension AccountBankModel {
             platformAvailable: "2000000000",
             state: .created
         )
+    ]
+
+    static let mockWithBackstopped = [
+        AccountBankModel.tradingETH,
+        AccountBankModel.trading,
+        AccountBankModel.fiat,
+        AccountBankModel.backstopped
     ]
 }


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [ ] Feature
- [X] Bug fix

### Linked issue

https://cybrid.atlassian.net/browse/CYB-1235

### Why

- Accounts Component: Order accounts ASC by name, taking as first always the FIAT accounts

![Captura de pantalla 2023-05-12 a la(s) 1 04 25](https://github.com/Cybrid-app/cybrid-sdk-ios/assets/7268597/8c4cca49-50b0-44f5-94b6-138635c3d7d4)


- Accounts Component: Inside an account (TradesView) the asset code balance in Fiat has an error showing as a crypto asset code

![Captura de pantalla 2023-05-12 a la(s) 1 13 19](https://github.com/Cybrid-app/cybrid-sdk-ios/assets/7268597/82bc11cc-2140-4dba-be9c-60a9dfa93618)


- Demo App: Disable the button to return (Navegation Bar) inside root controller allowing double login

![Captura de pantalla 2023-05-12 a la(s) 1 07 12](https://github.com/Cybrid-app/cybrid-sdk-ios/assets/7268597/72b886c0-fed2-4615-a1c6-34664a1cfe1f)

